### PR TITLE
Layer order & command optimisation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update && \
         ruby-dev \
         zlib1g-dev \
         build-essential && \
-    apt-get update && \
     gem install --no-document redis \
         resque-web \
         resque-scheduler-web && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,23 +2,29 @@ FROM ubuntu:18.04
 
 LABEL maintainer="team@appwrite.io"
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y ruby ruby-dev zlib1g-dev build-essential && \
-    apt-get update && \
-    gem install redis && \
-    gem install resque-web && \
-    gem install resque-scheduler-web && \
-    apt-get autoremove -y ruby-dev zlib1g-dev build-essential && \
-    apt-get clean -y
-
-ADD ./config.ru /config.ru
-ADD ./entrypoint.sh /entrypoint.sh
-
-RUN chmod 775 /entrypoint.sh
+EXPOSE 5678
 
 ENV RESQUE_WEB_HOST 127.0.0.1
 ENV RESQUE_WEB_PORT 6379
 
+COPY ./config.ru /config.ru
+COPY ./entrypoint.sh /entrypoint.sh
+
+RUN chmod 775 /entrypoint.sh
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y ruby \
+        ruby-dev \
+        zlib1g-dev \
+        build-essential && \
+    apt-get update && \
+    gem install redis \
+        resque-web \
+        resque-scheduler-web && \
+    apt-get autoremove -y ruby-dev \
+        zlib1g-dev \
+        build-essential && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
 ENTRYPOINT ["/entrypoint.sh"]
-EXPOSE 5678

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
         zlib1g-dev \
         build-essential && \
     apt-get update && \
-    gem install redis \
+    gem install --no-document redis \
         resque-web \
         resque-scheduler-web && \
     apt-get autoremove -y ruby-dev \


### PR DESCRIPTION
Moved layers that change frequently to later stages of build. 

Changed `ADD` instructions to `COPY`, as resources copied into image are local.

Removed `apt-get upgrade` as it causes updates that aren't necessary. It also causes image to change more frequently. All necessary updates are already in base image or performed when packages are installed.

Grouped `gem install` instructions into one to optimise build.

Added `rm` after installations to reduce image size.

Split install into multiple lines for readability.